### PR TITLE
Add inventory mode to evrtools for asset catalog

### DIFF
--- a/cmd/evrtools/inventory.go
+++ b/cmd/evrtools/inventory.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/EchoTools/evrFileTools/pkg/naming"
+)
+
+type typeStats struct {
+	typeSymbol naming.TypeSymbol
+	typeName   string
+	count      int
+	totalBytes int64
+}
+
+func runInventory() error {
+	if inputDir == "" {
+		return fmt.Errorf("inventory mode requires -input")
+	}
+
+	entries, err := os.ReadDir(inputDir)
+	if err != nil {
+		return fmt.Errorf("read directory: %w", err)
+	}
+
+	var stats []typeStats
+	totalFiles := 0
+	totalBytes := int64(0)
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Type directories are named as unsigned hex type symbols
+		val, err := strconv.ParseUint(entry.Name(), 16, 64)
+		if err != nil {
+			continue // skip non-hex directories
+		}
+		ts := naming.TypeSymbol(int64(val))
+
+		typeDir := filepath.Join(inputDir, entry.Name())
+		count, bytes, err := countFiles(typeDir)
+		if err != nil {
+			return fmt.Errorf("count files in %s: %w", typeDir, err)
+		}
+
+		stats = append(stats, typeStats{
+			typeSymbol: ts,
+			typeName:   ts.String(),
+			count:      count,
+			totalBytes: bytes,
+		})
+		totalFiles += count
+		totalBytes += bytes
+	}
+
+	// Sort by file count descending
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].count > stats[j].count
+	})
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TYPE\tFILES\tSIZE\tTYPE SYMBOL")
+	fmt.Fprintln(w, "----\t-----\t----\t-----------")
+	for _, s := range stats {
+		fmt.Fprintf(w, "%s\t%d\t%s\t0x%016x\n",
+			s.typeName,
+			s.count,
+			formatBytes(s.totalBytes),
+			uint64(s.typeSymbol),
+		)
+	}
+	fmt.Fprintln(w, "----\t-----\t----\t-----------")
+	fmt.Fprintf(w, "TOTAL\t%d\t%s\t\n", totalFiles, formatBytes(totalBytes))
+	w.Flush()
+
+	knownCount := 0
+	for _, s := range stats {
+		if naming.IsKnownType(s.typeSymbol) {
+			knownCount += s.count
+		}
+	}
+	unknownCount := totalFiles - knownCount
+	fmt.Printf("\n%d known types, %d unknown types (%d files known / %d files unknown)\n",
+		countKnownTypes(stats), len(stats)-countKnownTypes(stats), knownCount, unknownCount)
+
+	return nil
+}
+
+func countFiles(dir string) (int, int64, error) {
+	var count int
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			return 0, 0, err
+		}
+		count++
+		total += info.Size()
+	}
+	return count, total, nil
+}
+
+func formatBytes(b int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+	)
+	switch {
+	case b >= GB:
+		return fmt.Sprintf("%.1f GB", float64(b)/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.1f MB", float64(b)/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.1f KB", float64(b)/KB)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+func countKnownTypes(stats []typeStats) int {
+	n := 0
+	for _, s := range stats {
+		if naming.IsKnownType(s.typeSymbol) {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/evrtools/main.go
+++ b/cmd/evrtools/main.go
@@ -23,7 +23,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&mode, "mode", "", "Operation mode: extract, build")
+	flag.StringVar(&mode, "mode", "", "Operation mode: extract, build, inventory")
 	flag.StringVar(&packageName, "package", "", "Package name (e.g., 48037dc70b0ecab2)")
 	flag.StringVar(&dataDir, "data", "", "Path to _data directory containing manifests/packages")
 	flag.StringVar(&inputDir, "input", "", "Input directory for build mode")
@@ -48,8 +48,13 @@ func run() error {
 		return err
 	}
 
-	if err := prepareOutputDir(); err != nil {
-		return err
+	if mode != "inventory" {
+		if outputDir == "" {
+			return fmt.Errorf("output directory is required")
+		}
+		if err := prepareOutputDir(); err != nil {
+			return err
+		}
 	}
 
 	switch mode {
@@ -57,6 +62,8 @@ func run() error {
 		return runExtract()
 	case "build":
 		return runBuild()
+	case "inventory":
+		return runInventory()
 	default:
 		return fmt.Errorf("unknown mode: %s", mode)
 	}
@@ -65,9 +72,6 @@ func run() error {
 func validateFlags() error {
 	if mode == "" {
 		return fmt.Errorf("mode is required")
-	}
-	if outputDir == "" {
-		return fmt.Errorf("output directory is required")
 	}
 
 	switch mode {
@@ -82,8 +86,12 @@ func validateFlags() error {
 		if packageName == "" {
 			packageName = "package"
 		}
+	case "inventory":
+		if inputDir == "" {
+			return fmt.Errorf("inventory mode requires -input")
+		}
 	default:
-		return fmt.Errorf("mode must be 'extract' or 'build'")
+		return fmt.Errorf("mode must be 'extract', 'build', or 'inventory'")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Adds `evrtools -mode inventory` — walks an extracted directory and reports file counts and sizes by type
- Uses `pkg/naming` type mapper to display friendly names alongside hex type symbols
- Shows totals and a breakdown of known vs unknown types

## Usage

```bash
evrtools -mode inventory -input ./extracted
```

Example output:
```
TYPE             FILES   SIZE      TYPE SYMBOL
----             -----   ----      -----------
texture_dds      12275   2.8 GB    0xbeac1969cb7b8861
texture_bc_raw   17226   3.2 GB    0x7f5bc1cf8ce51ffd
texture_meta     12275   120.1 MB  0x2f6e61706a2c8f35
audio_ref        119     45.2 KB   0x38ee951a26fb816a
asset_ref        2109    1.2 MB    0xca6cd085401cbc87
unknown_...      9412    ...       0x...
----             -----   ----      -----------
TOTAL            53416   6.3 GB

5 known types, 18 unknown types (43804 files known / 9412 files unknown)
```

## Test plan

- [ ] Run against a fully extracted `_data` output directory
- [ ] Verify all known type symbols resolve to friendly names
- [ ] Verify unknown types print as `unknown_0x...`
- [ ] Test with an empty directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)